### PR TITLE
Ingest FITS spectra from tar files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # PyCharm
 .idea/
+
+# macOS directory info
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -40,3 +40,17 @@ FACILITIES = {
 }
 ```
 Keep in mind that Binospec and MMIRS programs have separate API keys even if they are part of the same proposal.
+
+If you want to be able to retrieve and ingest spectra from the MMT API, you need to configure your TOM to use the custom MMT data processor. Add the `'MMT'` line to the bottom of your `DATA_PRODUCT_TYPES` and `DATA_PROCESSORS` in `settings.py`:
+
+```python
+DATA_PRODUCT_TYPES = {
+    ...
+    'MMT': ('MMT', 'MMT File'),
+}
+
+DATA_PROCESSORS = {
+    ...
+    'MMT': 'tom_mmt.mmt.MMTDataProcessor',
+}
+```

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='tom-mmt',
-    version='0.1.2',
+    version='0.1.3',
     description='MMT Observatory module for the TOM Toolkit',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/tom_mmt/mmt.py
+++ b/tom_mmt/mmt.py
@@ -17,6 +17,9 @@ import re
 import mimetypes
 from tarfile import TarFile
 import os
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class MMTBaseObservationForm(BaseRoboticObservationForm):
@@ -438,14 +441,16 @@ class MMTDataProcessor(DataProcessor):
                     if member.name.endswith('_B.fits'):
                         fitsfile = tarfile.extractfile(member)
                         fitsname = os.path.basename(member.name)
-                        break
+                        logger.info('Untarring MMT file: {}'.format(data_product.data))
 
-            file = ContentFile(fitsfile.read(), fitsname)
-            data_product, created = DataProduct.objects.get_or_create(
-                product_id=member.name,
-                target=data_product.target,
-                observation_record=data_product.observation_record,
-                data=file,
-                data_product_type='spectroscopy',
-            )
+                        file = ContentFile(fitsfile.read(), fitsname)
+                        data_product, created = DataProduct.objects.get_or_create(
+                            product_id=member.name,
+                            target=data_product.target,
+                            observation_record=data_product.observation_record,
+                            data=file,
+                            data_product_type='spectroscopy',
+                        )
+                        logger.info('Saved new dataproduct: {}'.format(data_product.data))
+                        break
         return run_data_processor(data_product)

--- a/tom_mmt/mmt.py
+++ b/tom_mmt/mmt.py
@@ -346,6 +346,7 @@ class MMTFacility(BaseRoboticObservationFacility):
                 dp.data.save(product['filename'], dfile)
                 dp.save()
                 logger.info('Saved new dataproduct: {}'.format(dp.data))
+                run_data_processor(dp)
             if settings.AUTO_THUMBNAILS:
                 create_image_dataproduct(dp)
                 dp.get_preview()

--- a/tom_mmt/mmt.py
+++ b/tom_mmt/mmt.py
@@ -1,8 +1,12 @@
 from tom_observations.facility import BaseRoboticObservationForm, BaseRoboticObservationFacility
 from tom_observations.models import ObservationRecord
+from tom_dataproducts.data_processor import run_data_processor, DataProcessor
+from tom_dataproducts.models import DataProduct
+from tom_dataproducts.utils import create_image_dataproduct
 from tom_targets.models import Target
 from astropy.coordinates import SkyCoord
 from django import forms
+from django.core.files.base import ContentFile
 from crispy_forms.layout import Layout, Row, Column
 from crispy_forms.bootstrap import AppendedText
 import pymmt
@@ -10,6 +14,9 @@ from django.conf import settings
 import requests
 from datetime import datetime
 import re
+import mimetypes
+from tarfile import TarFile
+import os
 
 
 class MMTBaseObservationForm(BaseRoboticObservationForm):
@@ -319,6 +326,29 @@ class MMTFacility(BaseRoboticObservationFacility):
 
         return data_products
 
+    def save_data_products(self, observation_record, product_id=None):
+        final_products = []
+        products = self.data_products(observation_record.observation_id, product_id)
+
+        for product in products:
+            dp, created = DataProduct.objects.get_or_create(
+                product_id=product['id'],
+                target=observation_record.target,
+                observation_record=observation_record,
+                data_product_type=product['type'],  # same as the built-in method except for this line
+            )
+            if created:
+                product_data = requests.get(product['url']).content
+                dfile = ContentFile(product_data)
+                dp.data.save(product['filename'], dfile)
+                dp.save()
+                logger.info('Saved new dataproduct: {}'.format(dp.data))
+            if AUTO_THUMBNAILS:
+                create_image_dataproduct(dp)
+                dp.get_preview()
+            final_products.append(dp)
+        return final_products
+
     def get_form(self, observation_type):
         return self.observation_forms.get(observation_type, MMTBaseObservationForm)
 
@@ -397,3 +427,25 @@ class MMTFacility(BaseRoboticObservationFacility):
     def get_facility_weather_urls(self):
         return {'code': 'MMT', 'sites': [{'code': 'flwo',
                                           'weather_url': 'https://www.mmto.org/current-weather-at-the-mmt/'}]}
+
+
+class MMTDataProcessor(DataProcessor):
+    def process_data(self, data_product):
+        mimetype = mimetypes.guess_type(data_product.data.path)[0]
+        if mimetype == 'application/x-tar':
+            with TarFile(fileobj=data_product.data) as tarfile:
+                for member in tarfile.getmembers():
+                    if member.name.endswith('_B.fits'):
+                        fitsfile = tarfile.extractfile(member)
+                        fitsname = os.path.basename(member.name)
+                        break
+
+            file = ContentFile(fitsfile.read(), fitsname)
+            data_product, created = DataProduct.objects.get_or_create(
+                product_id=member.name,
+                target=data_product.target,
+                observation_record=data_product.observation_record,
+                data=file,
+                data_product_type='spectroscopy',
+            )
+        return run_data_processor(data_product)

--- a/tom_mmt/mmt.py
+++ b/tom_mmt/mmt.py
@@ -451,6 +451,5 @@ class MMTDataProcessor(DataProcessor):
                             data_product_type='spectroscopy',
                         )
                         logger.info('Saved new dataproduct: {}'.format(dp.data))
-                        return run_data_processor(dp)
-        else:
-            return []
+                        run_data_processor(dp)
+        return []

--- a/tom_mmt/mmt.py
+++ b/tom_mmt/mmt.py
@@ -335,7 +335,7 @@ class MMTFacility(BaseRoboticObservationFacility):
                 product_id=product['id'],
                 target=observation_record.target,
                 observation_record=observation_record,
-                data_product_type=product['type'],  # same as the built-in method except for this line
+                data_product_type='MMT',  # same as the built-in method except for this line
             )
             if created:
                 product_data = requests.get(product['url']).content

--- a/tom_mmt/mmt.py
+++ b/tom_mmt/mmt.py
@@ -346,7 +346,7 @@ class MMTFacility(BaseRoboticObservationFacility):
                 dp.data.save(product['filename'], dfile)
                 dp.save()
                 logger.info('Saved new dataproduct: {}'.format(dp.data))
-            if AUTO_THUMBNAILS:
+            if settings.AUTO_THUMBNAILS:
                 create_image_dataproduct(dp)
                 dp.get_preview()
             final_products.append(dp)


### PR DESCRIPTION
This implements a custom `MMTDataProcessor` that extracts the 1D spectrum FITS files from the tar and runs the normal data processor on the FITS file. To do this, I had to create a new `'MMT'` data product type that applies to all data retrieved by this package.